### PR TITLE
ci: reuse steps between lint/test, only build on test success

### DIFF
--- a/.github/setup/action.yml
+++ b/.github/setup/action.yml
@@ -1,0 +1,36 @@
+name: Setup Step
+
+description: |
+  This step sets up Python and Poetry, and caches the virtual environment.
+  It is intended to be used as a step in a workflow that runs Python code.
+
+inputs:
+  python-version:
+    required: true
+    description: "Python version to use with `actions/setup-python`"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up Poetry
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip poetry
+        poetry config virtualenvs.create true --local
+        poetry config virtualenvs.in-project true --local
+
+    - name: Use venv cache
+      uses: actions/cache@v3
+      with:
+        path: ./.venv
+        key: venv-${{ hashFiles('poetry.lock') }}-${{ inputs.python-version }}
+
+    - name: Install project
+      shell: bash
+      run: |
+        poetry --no-ansi --no-interaction install

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -2,10 +2,10 @@ name: Build Image
 
 on:
   push:
-    branches:
-      - "**"
     tags:
       - "v**"
+  workflow_call:
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,26 +19,9 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: ./.github/setup
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up Poetry
-        run: |
-          python -m pip install --upgrade pip poetry
-          poetry config virtualenvs.create true --local
-          poetry config virtualenvs.in-project true --local
-
-      - name: Use venv cache
-        uses: actions/cache@v3
-        with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}
-
-      - name: Install project
-        run: |
-          poetry --no-ansi --no-interaction install
 
       - name: Lint - ruff
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,11 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  build-image:
+    needs: test
+    uses: ./.github/workflows/build-image.yml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,26 +19,9 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - uses: ./.github/setup
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Set up Poetry
-        run: |
-          python -m pip install --upgrade pip poetry
-          poetry config virtualenvs.create true --local
-          poetry config virtualenvs.in-project true --local
-
-      - name: Use venv cache
-        uses: actions/cache@v3
-        with:
-          path: ./.venv
-          key: venv-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}
-
-      - name: Install project
-        run: |
-          poetry --no-ansi --no-interaction install
 
       - name: Test
         run: poetry run poe test


### PR DESCRIPTION
Modifies CI/CD pipeline:

- Extracts duplicated sections from `lint.yml` and `test.yml` into a reusable composite workflow in `.github/setup/`.
- `build-image` no longer triggered on push to branches, only tags, as a dependency, or as a manually triggered workflow.
- `test` now runs `build-image` only when it succeeds.