### PR TITLE
refactor(repository): remove unique proposal no restriction, simplify file io

### DIFF
--- a/src/zulip_write_only_proxy/repositories.py
+++ b/src/zulip_write_only_proxy/repositories.py
@@ -24,16 +24,7 @@ class JSONRepository(BaseModel):
 
             return models.ScopedClient(key=SecretStr(key), **client_data)
 
-    def put(self, client: models.ScopedClient) -> None:
-        with file_lock:
-            with self.path.open("rb") as f:
-                data: dict[str, dict] = orjson.loads(f.read())
-                data[client.key.get_secret_value()] = client.model_dump(exclude={"key"})
-
-            with self.path.open("wb") as f:
-                f.write(orjson.dumps(data, option=orjson.OPT_INDENT_2))
-
-    def put_admin(self, client: models.AdminClient) -> None:
+    def put(self, client: models.Client) -> None:
         with file_lock:
             with self.path.open("rb") as f:
                 data: dict[str, dict] = orjson.loads(f.read())

--- a/src/zulip_write_only_proxy/repositories.py
+++ b/src/zulip_write_only_proxy/repositories.py
@@ -28,18 +28,6 @@ class JSONRepository(BaseModel):
         with file_lock:
             with self.path.open("rb") as f:
                 data: dict[str, dict] = orjson.loads(f.read())
-                proposal_nos = [value.get("proposal_no") for value in data.values()]
-                if client.proposal_no in proposal_nos:
-                    reversed_data = {
-                        value.get("proposal_no"): {"key": key, **value}
-                        for key, value in data.items()
-                    }
-
-                    raise ValueError(
-                        f"Client already exists for {client.proposal_no=}: "
-                        f"{reversed_data[client.proposal_no]}"
-                    )
-
                 data[client.key.get_secret_value()] = client.model_dump(exclude={"key"})
 
             with self.path.open("wb") as f:

--- a/src/zulip_write_only_proxy/services.py
+++ b/src/zulip_write_only_proxy/services.py
@@ -19,7 +19,7 @@ def create_client(proposal_no: int, stream: str | None = None) -> models.ScopedC
 
 def create_admin() -> models.AdminClient:
     client = models.AdminClient.create()
-    REPOSITORY.put_admin(client)
+    REPOSITORY.put(client)
     return client
 
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -53,9 +53,6 @@ def test_put_scoped_client(repository: JSONRepository):
     assert result.stream == "Test Stream 3"
     assert result.proposal_no == 3
 
-    with pytest.raises(ValueError):
-        repository.put(client)
-
 
 def test_put_admin_client(repository: JSONRepository):
     client = AdminClient(key="admin2", admin=True)  # type: ignore[arg-type]

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -57,7 +57,7 @@ def test_put_scoped_client(repository: JSONRepository):
 def test_put_admin_client(repository: JSONRepository):
     client = AdminClient(key="admin2", admin=True)  # type: ignore[arg-type]
 
-    repository.put_admin(client)
+    repository.put(client)
 
     result = repository.get(client.key.get_secret_value())
 


### PR DESCRIPTION
PR simplifies the locking/file IO logic in the repository and removes the restriction on clients having a unique proposal associated with them.

No real external effects caused by changes.